### PR TITLE
Don't deliver confirmed messages over the WebSocket

### DIFF
--- a/ws.js
+++ b/ws.js
@@ -85,6 +85,13 @@ function WebSocketClient(cfg) {
 				return;
 			}
 
+			for (var i = 0; i < confirmIds.length; i++) {
+				var id = confirmIds[i];
+				if (msg[id]) {
+					delete msg[id];
+				}
+			}
+
 			that.emit('delivery', msg);
 		};
 


### PR DESCRIPTION
This avoids double emission because of the disconnected behavior of sending/receiving messages (unlike other transports).